### PR TITLE
Fix gas limit

### DIFF
--- a/src/wallet-pay-eth.js
+++ b/src/wallet-pay-eth.js
@@ -158,7 +158,7 @@ class WalletPayEthereum extends EvmPay {
       from: sender.address,
       to: outgoing.address,
       value: amount.toBaseUnit(),
-      gas: outgoing.gasLimit || (await web3.eth.getBlock()).gasLimit,
+      gas: outgoing.gasLimit,
       gasPrice: outgoing.gasPrice || await this._getGasPrice(),
       data: outgoing.data
     }

--- a/src/wallet-pay-eth.js
+++ b/src/wallet-pay-eth.js
@@ -154,11 +154,22 @@ class WalletPayEthereum extends EvmPay {
 
     if (!sender) throw new Error('insufficient balance or invalid sender')
 
+    let gasLimit = outgoing.gasLimit;
+
+    if (!gasLimit) {
+      gasLimit = await web3.eth.estimateGas({
+        from: sender.address,
+        to: outgoing.address,
+        value: amount.toBaseUnit(),
+        data: outgoing.data
+      })
+    }
+
     const tx = {
       from: sender.address,
       to: outgoing.address,
       value: amount.toBaseUnit(),
-      gas: outgoing.gasLimit,
+      gas: gasLimit,
       gasPrice: outgoing.gasPrice || await this._getGasPrice(),
       data: outgoing.data
     }


### PR DESCRIPTION
A transaction with a gas limit equal to the block gas limit would likely revert during simulation, as the estimated gas cost to send it could be 100 or 1000 times higher than the actual gas used.

Since users only pay for the gas actually consumed, a block containing only this transaction (potentially saturating the entire block's gas capacity) wouldn't be economically viable. Block builders would likely prioritize other transactions, leaving this one stranded in the mempool indefinitely until it's replaced